### PR TITLE
Fix README GitHub Pages URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,1 @@
-[https://github.io/reporepo1](https://github.io/reporepo1)
+[https://tarosay.github.io/reporepo1/](https://tarosay.github.io/reporepo1/)


### PR DESCRIPTION
## Summary
- update the README link to point at the published GitHub Pages site

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68cbeb1da0c0832095240a7de989903e